### PR TITLE
Check a type's base type to determine if it has an id

### DIFF
--- a/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
+++ b/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
@@ -377,8 +377,14 @@ public class ClassWriter extends JavaWriter {
         
         // Now the service
         if (!type.meta.noservice) {
-            if (type.meta.properties.containsKey("id")) {
-                if (type.meta.properties.containsKey("globalIdentifier")) {
+
+            Boolean containsId = type.meta.properties.containsKey("id")
+                    || type.baseMeta.properties.containsKey("id");
+            Boolean containsGlobalIdentifier = type.meta.properties.containsKey("globalIdentifier")
+                    || type.baseMeta.properties.containsKey("globalIdentifier");
+
+            if (containsId) {
+                if (containsGlobalIdentifier) {
                     beginMethod("Service", "asService", PUBLIC, TYPE_API_CLIENT, "client").
                         beginControlFlow("if (id != null)").
                             emitStatement("return service(client, id)").
@@ -395,11 +401,11 @@ public class ClassWriter extends JavaWriter {
                 emitStatement("return client.createService(Service.class, null)").
                 endMethod().emitEmptyLine();
 
-            if (type.meta.properties.containsKey("id")) {
+            if (containsId) {
                 beginMethod("Service", "service", PUBLIC_STATIC, TYPE_API_CLIENT, "client", "Long", "id").
                     emitStatement("return client.createService(Service.class, id == null ? null : id.toString())").
                     endMethod().emitEmptyLine();
-                if (type.meta.properties.containsKey("globalIdentifier")) {
+                if (containsGlobalIdentifier) {
                     beginMethod("Service", "service", PUBLIC_STATIC, TYPE_API_CLIENT,
                             "client", "String", "globalIdentifier").
                         emitStatement("return client.createService(Service.class, globalIdentifier)").

--- a/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
+++ b/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
@@ -59,13 +59,13 @@ public class ClassWriter extends JavaWriter {
         }
     }
     
-    public static void emitType(File baseDir, TypeClass type) throws IOException {
+    public static void emitType(File baseDir, TypeClass type, Meta meta) throws IOException {
         File fileDir = new File(baseDir, type.packageName.replace('.', '/'));
         fileDir.mkdirs();
         Writer writer = new BufferedWriter(new OutputStreamWriter(
             new FileOutputStream(new File(fileDir, type.className + ".java")), "UTF-8"));
         try {
-            new ClassWriter(writer, type).emitType();
+            new ClassWriter(writer, type, meta).emitType();
         } finally {
             try { writer.close(); } catch (Exception e) { }
         }
@@ -86,10 +86,12 @@ public class ClassWriter extends JavaWriter {
     }
     
     public final TypeClass type;
+    private final Meta meta;
     
-    public ClassWriter(Writer out, TypeClass type) {
+    public ClassWriter(Writer out, TypeClass type, Meta meta) {
         super(out);
         this.type = type;
+        this.meta = meta;
         setIndent("    ");
     }
 
@@ -378,10 +380,20 @@ public class ClassWriter extends JavaWriter {
         // Now the service
         if (!type.meta.noservice) {
 
-            Boolean containsId = type.meta.properties.containsKey("id")
-                    || type.baseMeta.properties.containsKey("id");
-            Boolean containsGlobalIdentifier = type.meta.properties.containsKey("globalIdentifier")
-                    || type.baseMeta.properties.containsKey("globalIdentifier");
+            // Check if the type or any of its' parent types have id or globalIdentifier properties
+            Boolean containsId = false;
+            Boolean containsGlobalIdentifier = false;
+            Meta.Type searchType = type.meta;
+            while (searchType != null) {
+                if (searchType.properties.containsKey("id")) {
+                    containsId = true;
+                    if (searchType.properties.containsKey("globalIdentifier")) {
+                        containsGlobalIdentifier = true;
+                    }
+                    break;
+                }
+                searchType = meta.types.get(searchType.base);
+            }
 
             if (containsId) {
                 if (containsGlobalIdentifier) {
@@ -415,7 +427,7 @@ public class ClassWriter extends JavaWriter {
             
             emitService();
         }
-        
+
         emitMask().endType();
         return this;
     }

--- a/gen/src/main/java/com/softlayer/api/gen/Generator.java
+++ b/gen/src/main/java/com/softlayer/api/gen/Generator.java
@@ -35,7 +35,7 @@ public class Generator {
         List<TypeClass> classes = new ArrayList<TypeClass>(meta.types.size());
         for (Meta.Type type : meta.types.values()) {
             TypeClass typeClass = new MetaConverter(BASE_PKG, meta, type).buildTypeClass();
-            ClassWriter.emitType(dir, typeClass);
+            ClassWriter.emitType(dir, typeClass, meta);
             classes.add(typeClass);
         }
         ClassWriter.emitPackageInfo(dir, classes);


### PR DESCRIPTION
Changes the ClassWriter to take into account the base type to see if id or service identifier properties exist when generating service methods.

Addresses #21