### PR TITLE
Add support for object filters

### DIFF
--- a/examples/src/main/java/com/softlayer/api/example/ListServers.java
+++ b/examples/src/main/java/com/softlayer/api/example/ListServers.java
@@ -3,6 +3,7 @@ package com.softlayer.api.example;
 import com.softlayer.api.ApiClient;
 import com.softlayer.api.service.Account;
 import com.softlayer.api.service.Hardware;
+import com.softlayer.api.service.software.Description;
 import com.softlayer.api.service.virtual.Guest;
 
 /** List all physical and virtual servers on an account */
@@ -13,23 +14,23 @@ public class ListServers extends Example {
         Account.Service service = Account.service(client);
         
         // To get specific information on an account (servers in this case) a mask is provided
-        service.withMask().hardware().
-            fullyQualifiedDomainName().
-            primaryIpAddress().
-            primaryBackendIpAddress();
-        service.withMask().hardware().operatingSystem().softwareLicense().softwareDescription().
-            manufacturer().
-            name().
-            version();
-        service.withMask().virtualGuests().
-            fullyQualifiedDomainName().
-            primaryIpAddress().
-            primaryBackendIpAddress();
-        service.withMask().virtualGuests().operatingSystem().softwareLicense().softwareDescription().
-            manufacturer().
-            name().
-            version();
-        
+        Hardware.Mask hardwareMask = service.withMask().hardware();
+        hardwareMask.fullyQualifiedDomainName();
+        hardwareMask.primaryIpAddress();
+        hardwareMask.primaryBackendIpAddress();
+        Description.Mask descriptionMask = hardwareMask.operatingSystem().softwareLicense().softwareDescription();
+        descriptionMask.manufacturer();
+        descriptionMask.name();
+        descriptionMask.version();
+        Guest.Mask guestMask = service.withMask().virtualGuests();
+        guestMask.fullyQualifiedDomainName();
+        guestMask.primaryIpAddress();
+        guestMask.primaryBackendIpAddress();
+        descriptionMask = guestMask.operatingSystem().softwareLicense().softwareDescription();
+        descriptionMask.manufacturer();
+        descriptionMask.name();
+        descriptionMask.version();
+
         // Calling getObject will now use the mask
         Account account = service.getObject();
 

--- a/examples/src/main/java/com/softlayer/api/example/ListServersAsync.java
+++ b/examples/src/main/java/com/softlayer/api/example/ListServersAsync.java
@@ -4,6 +4,7 @@ import com.softlayer.api.ApiClient;
 import com.softlayer.api.ResponseHandler;
 import com.softlayer.api.service.Account;
 import com.softlayer.api.service.Hardware;
+import com.softlayer.api.service.software.Description;
 import com.softlayer.api.service.virtual.Guest;
 
 /** Asynchronous version of {@link ListServers} */
@@ -14,22 +15,22 @@ public class ListServersAsync extends Example {
         Account.Service service = Account.service(client);
 
         // To get specific information on an account (servers in this case) a mask is provided
-        service.withMask().hardware().
-            fullyQualifiedDomainName().
-            primaryIpAddress().
-            primaryBackendIpAddress();
-        service.withMask().hardware().operatingSystem().softwareLicense().softwareDescription().
-            manufacturer().
-            name().
-            version();
-        service.withMask().virtualGuests().
-            fullyQualifiedDomainName().
-            primaryIpAddress().
-            primaryBackendIpAddress();
-        service.withMask().virtualGuests().operatingSystem().softwareLicense().softwareDescription().
-            manufacturer().
-            name().
-            version();
+        Hardware.Mask hardwareMask = service.withMask().hardware();
+        hardwareMask.fullyQualifiedDomainName();
+        hardwareMask.primaryIpAddress();
+        hardwareMask.primaryBackendIpAddress();
+        Description.Mask descriptionMask = hardwareMask.operatingSystem().softwareLicense().softwareDescription();
+        descriptionMask.manufacturer();
+        descriptionMask.name();
+        descriptionMask.version();
+        Guest.Mask guestMask = service.withMask().virtualGuests();
+        guestMask.fullyQualifiedDomainName();
+        guestMask.primaryIpAddress();
+        guestMask.primaryBackendIpAddress();
+        descriptionMask = guestMask.operatingSystem().softwareLicense().softwareDescription();
+        descriptionMask.manufacturer();
+        descriptionMask.name();
+        descriptionMask.version();
 
         // Calling getObject will now use the mask
         // By using asAsync this runs on a separate thread pool, and get() is called on the resulting future

--- a/examples/src/main/java/com/softlayer/api/example/OrderVirtualServer.java
+++ b/examples/src/main/java/com/softlayer/api/example/OrderVirtualServer.java
@@ -85,7 +85,9 @@ public class OrderVirtualServer extends Example {
                 guest.getId(), minutesToWait);
         } else {
             // Using a mask, we can ask for the operating system password
-            service.withNewMask().primaryIpAddress().operatingSystem().passwords();
+            Guest.Mask mask = service.withNewMask();
+            mask.primaryIpAddress();
+            mask.operatingSystem().passwords();
             guest = service.getObject();
             if (guest.getOperatingSystem() == null) {
                 System.out.println("Unable to find operating system on completed guest");

--- a/src/main/java/com/softlayer/api/Filter.java
+++ b/src/main/java/com/softlayer/api/Filter.java
@@ -1,0 +1,161 @@
+package com.softlayer.api;
+
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class Filter {
+    protected abstract Map<String, ?> getFilterMap();
+
+    public enum SimpleOperation {
+        EQUAL_TO {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return value;
+            }
+        },
+        NOT_EQUAL_TO {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "!= " + value;
+            }
+        },
+        GREATER_THAN {
+            String withValue(String value) {
+                requireNotNull(value);
+                return "> " + value;
+            }
+        },
+        GREATER_OR_EQUAL_TO {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return ">= " + value;
+            }
+        },
+        LESS_THAN {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "< " + value;
+            }
+        },
+        LESS_OR_EQUAL_TO {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "<= " + value;
+            }
+        },
+        STARTS_WITH {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "^= " + value;
+            }
+        },
+        NOT_STARTS_WITH {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "!^= " + value;
+            }
+        },
+        ENDS_WITH {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "$= " + value;
+            }
+        },
+        NOT_ENDS_WITH {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "!$= " + value;
+            }
+        },
+        CONTAINS {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "*= " + value;
+            }
+        },
+        NOT_CONTAINS {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "!*= " + value;
+            }
+        },
+        EQUAL_TO_IGNORE_CASE {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "_= " + value;
+            }
+        },
+        NOT_EQUAL_TO_IGNORE_CASE {
+            @Override
+            String withValue(String value) {
+                requireNotNull(value);
+                return "!_= " + value;
+            }
+        },
+        NOT_NULL {
+            @Override
+            String withValue(String value) {
+                requireNull(value);
+                return "not null";
+            }
+        },
+        IS_NULL {
+            @Override
+            String withValue(String value) {
+                requireNull(value);
+                return "null";
+            }
+        };
+
+        void requireNull(String value) {
+            if (value != null) {
+                throw new IllegalArgumentException("Null is required for operation " + this);
+            }
+        }
+
+        void requireNotNull(String value) {
+            if (value == null) {
+                throw new IllegalArgumentException("Null is not allowed for operation " + this);
+            }
+        }
+
+        abstract String withValue(String value);
+    }
+
+    public static class SimpleFilter<T> extends Filter {
+        private final SimpleOperation operation;
+        private final T value;
+
+        public SimpleFilter(SimpleOperation operation, T value) {
+            this.operation = operation;
+            this.value = value;
+        }
+
+        public SimpleOperation getOperation() {
+            return operation;
+        }
+
+        public T getValue() {
+            return value;
+        }
+
+        @Override
+        protected Map<String, ?> getFilterMap() {
+            return Collections.singletonMap("operation", getOperation().withValue(
+                    getValue() == null ? null : getValue().toString()
+            ));
+        }
+    }
+}

--- a/src/main/java/com/softlayer/api/Filterable.java
+++ b/src/main/java/com/softlayer/api/Filterable.java
@@ -1,0 +1,21 @@
+package com.softlayer.api;
+
+/**
+ * Interface implemented by services that accept filters for some calls.
+ */
+public interface Filterable {
+    /** Overwrite the existing filter on this object with a new one and return it. */
+    public Mask withNewFilter();
+
+    /** Use the existing filter on this object or create it if not present. */
+    public Mask withFilter();
+
+    /** Set the filter to the given object. */
+    public void setFilter(Mask filter);
+
+    /** Set the filter to a string. */
+    public void setFilter(String filter);
+
+    /** Removes the filter from this object. */
+    public void clearFilter();
+}

--- a/src/main/java/com/softlayer/api/Mask.java
+++ b/src/main/java/com/softlayer/api/Mask.java
@@ -1,13 +1,17 @@
 package com.softlayer.api;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+
+import com.softlayer.api.Property.BooleanProperty;
+import com.softlayer.api.Property.ByteArrayProperty;
+import com.softlayer.api.Property.DateTimeProperty;
+import com.softlayer.api.Property.NumberProperty;
+import com.softlayer.api.Property.StringProperty;
 
 /** Object mask parameter. See http://sldn.softlayer.com/article/Object-Masks */
 public class Mask {
-    private final Set<String> localProperties = new HashSet<String>();
+    private final Map<String, Property<?>> localProperties = new HashMap<String, Property<?>>();
     private final Map<String, Mask> subMasks = new HashMap<String, Mask>();
     
     /** Clear out all previously masked objects and local properties */
@@ -20,8 +24,49 @@ public class Mask {
         return localProperties.size() + subMasks.size();
     }
 
-    protected void withLocalProperty(String localProperty) {
-        localProperties.add(localProperty);
+    protected BooleanProperty withBooleanProperty(String name) {
+        Property<?> property = localProperties.get(name);
+        if (property == null) {
+            property = new BooleanProperty(name);
+            localProperties.put(name, property);
+        }
+        return (BooleanProperty) property;
+    }
+
+    protected ByteArrayProperty withByteArrayProperty(String name) {
+        Property<?> property = localProperties.get(name);
+        if (property == null) {
+            property = new ByteArrayProperty(name);
+            localProperties.put(name, property);
+        }
+        return (ByteArrayProperty) property;
+    }
+
+    protected DateTimeProperty withDateTimeProperty(String name) {
+        Property<?> property = localProperties.get(name);
+        if (property == null) {
+            property = new DateTimeProperty(name);
+            localProperties.put(name, property);
+        }
+        return (DateTimeProperty) property;
+    }
+
+    protected NumberProperty withNumberProperty(String name) {
+        Property<?> property = localProperties.get(name);
+        if (property == null) {
+            property = new NumberProperty(name);
+            localProperties.put(name, property);
+        }
+        return (NumberProperty) property;
+    }
+
+    protected StringProperty withStringProperty(String name) {
+        Property<?> property = localProperties.get(name);
+        if (property == null) {
+            property = new StringProperty(name);
+            localProperties.put(name, property);
+        }
+        return (StringProperty) property;
     }
 
     @SuppressWarnings("unchecked")
@@ -50,7 +95,7 @@ public class Mask {
     /** Append this mask's string representation to the given builder and return it */
     public StringBuilder toString(StringBuilder builder) {
         boolean first = true;
-        for (String localProperty : localProperties) {
+        for (String localProperty : localProperties.keySet()) {
             if (first) {
                 first = false;
             } else {
@@ -76,5 +121,24 @@ public class Mask {
             }
         }
         return builder;
+    }
+
+    protected Map<String, ?> getFilterMap() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        // Sub masks first
+        for (Map.Entry<String, Mask> subMask : subMasks.entrySet()) {
+            Map<String, ?> subMap = subMask.getValue().getFilterMap();
+            if (!subMap.isEmpty()) {
+                map.put(subMask.getKey(), subMap);
+            }
+        }
+        // Now local properties
+        for (Map.Entry<String, Property<?>> localProperty : localProperties.entrySet()) {
+            Map<String, ?> localPropertyMap = localProperty.getValue().getFilterMap();
+            if (!localPropertyMap.isEmpty()) {
+                map.put(localProperty.getKey(), localPropertyMap);
+            }
+        }
+        return map;
     }
 }

--- a/src/main/java/com/softlayer/api/Property.java
+++ b/src/main/java/com/softlayer/api/Property.java
@@ -1,0 +1,143 @@
+package com.softlayer.api;
+
+import com.softlayer.api.Filter.SimpleFilter;
+import com.softlayer.api.Filter.SimpleOperation;
+
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.Map;
+
+public abstract class Property<T> {
+    public final String name;
+    private Filter filter;
+
+    Property(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Filter getFilter() {
+        return filter;
+    }
+
+    public void setFilter(Filter filter) {
+        this.filter = filter;
+    }
+
+    public void equalTo(T value) {
+        if (value == null) {
+            isNull();
+        } else {
+            setFilter(new SimpleFilter<T>(SimpleOperation.EQUAL_TO, value));
+        }
+    }
+
+    public void notEqualTo(T value) {
+        if (value == null) {
+            notNull();
+        } else {
+            setFilter(new SimpleFilter<T>(SimpleOperation.NOT_EQUAL_TO, value));
+        }
+    }
+
+    public void isNull() {
+        setFilter(new SimpleFilter<T>(SimpleOperation.IS_NULL, null));
+    }
+
+    public void notNull() {
+        setFilter(new SimpleFilter<T>(SimpleOperation.NOT_EQUAL_TO, null));
+    }
+
+    protected Map<String, ?> getFilterMap() {
+        if (getFilter() == null) {
+            return Collections.emptyMap();
+        }
+        return getFilter().getFilterMap();
+    }
+
+    public static class BooleanProperty extends Property<Boolean> {
+        public BooleanProperty(String name) {
+            super(name);
+        }
+    }
+
+    public static class ByteArrayProperty extends Property<byte[]> {
+        public ByteArrayProperty(String name) {
+            super(name);
+        }
+
+        @Override
+        public void setFilter(Filter filter) {
+            throw new UnsupportedOperationException("Byte arrays do not support filters");
+        }
+    }
+
+    public static class DateTimeProperty extends Property<GregorianCalendar> {
+        protected DateTimeProperty(String name) {
+            super(name);
+        }
+    }
+
+    public static class NumberProperty extends Property<Number> {
+        protected NumberProperty(String name) {
+            super(name);
+        }
+
+        public void greaterThan(Number value) {
+            setFilter(new SimpleFilter<Number>(SimpleOperation.GREATER_THAN, value));
+        }
+
+        public void greaterOrEqualTo(Number value) {
+            setFilter(new SimpleFilter<Number>(SimpleOperation.GREATER_OR_EQUAL_TO, value));
+        }
+
+        public void lessThan(Number value) {
+            setFilter(new SimpleFilter<Number>(SimpleOperation.LESS_THAN, value));
+        }
+
+        public void lessOrEqualTo(Number value) {
+            setFilter(new SimpleFilter<Number>(SimpleOperation.LESS_OR_EQUAL_TO, value));
+        }
+    }
+
+    public static class StringProperty extends Property<String> {
+        public StringProperty(String name) {
+            super(name);
+        }
+
+        public void startsWith(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.STARTS_WITH, value));
+        }
+
+        public void notStartsWith(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.NOT_STARTS_WITH, value));
+        }
+
+        public void endsWith(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.ENDS_WITH, value));
+        }
+
+        public void notEndsWith(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.NOT_ENDS_WITH, value));
+        }
+
+        public void contains(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.CONTAINS, value));
+        }
+
+        public void notContains(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.NOT_CONTAINS, value));
+        }
+
+        public void equalToIgnoreCase(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.EQUAL_TO_IGNORE_CASE, value));
+        }
+
+        public void notEqualToIgnoreCase(String value) {
+            setFilter(new SimpleFilter<String>(SimpleOperation.NOT_EQUAL_TO_IGNORE_CASE, value));
+        }
+    }
+}

--- a/src/main/java/com/softlayer/api/RestApiClient.java
+++ b/src/main/java/com/softlayer/api/RestApiClient.java
@@ -137,8 +137,9 @@ public class RestApiClient implements ApiClient {
     }
     
     protected String getFullUrl(String serviceName, String methodName, String id,
-            ResultLimit resultLimit, String maskString) {
-        StringBuilder url = new StringBuilder(baseUrl + serviceName);
+            ResultLimit resultLimit, String maskString, String filterString) {
+        StringBuilder url = new StringBuilder(baseUrl);
+        url.append(serviceName);
         // ID present? add it
         if (id != null) {
             url.append('/').append(id);
@@ -152,17 +153,32 @@ public class RestApiClient implements ApiClient {
             url.append('/').append(methodName);
         }
         url.append(".json");
+
+        StringBuilder urlParameters = new StringBuilder();
+
         if (resultLimit != null) {
-            url.append("?resultLimit=").append(resultLimit.offset).append(',').append(resultLimit.limit);
+            urlParameters.append("?resultLimit=")
+                    .append(resultLimit.offset)
+                    .append(',')
+                    .append(resultLimit.limit);
         }
         if (maskString != null && !maskString.isEmpty()) {
-            url.append(resultLimit == null ? '?' : '&');
+            urlParameters.append(urlParameters.length() == 0 ? '?' : '&');
             try {
-                url.append("objectMask=").append(URLEncoder.encode(maskString, "UTF-8"));
+                urlParameters.append("objectMask=").append(URLEncoder.encode(maskString, "UTF-8"));
             } catch (UnsupportedEncodingException e) {
                 throw new RuntimeException(e);
             }
         }
+        if (filterString != null && !filterString.isEmpty()) {
+            urlParameters.append(urlParameters.length() == 0 ? '?' : '&');
+            try {
+                urlParameters.append("objectFilter=").append(URLEncoder.encode(filterString, "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        url.append(urlParameters);
         return url.toString();
     }
     
@@ -194,17 +210,31 @@ public class RestApiClient implements ApiClient {
     }
 
     class ServiceProxy<S extends Service> implements InvocationHandler {
-        
+
         final Class<S> serviceClass;
         final String id;
         Mask mask;
         String maskString;
+        Mask filter;
+        String filterString;
         ResultLimit resultLimit;
         Integer lastResponseTotalItemCount;
         
         public ServiceProxy(Class<S> serviceClass, String id) {
             this.serviceClass = serviceClass;
             this.id = id;
+        }
+
+        protected String getFilterString() throws UnsupportedEncodingException {
+            if (filter != null) {
+                Map<String, ?> filterMap = filter.getFilterMap();
+                if (!filterMap.isEmpty()) {
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    getJsonMarshallerFactory().getJsonMarshaller().toJson(filterMap, out);
+                    return out.toString("UTF-8");
+                }
+            }
+            return filterString;
         }
         
         public void logRequestAndWriteBody(HttpClient client, String httpMethod, String url, Object[] args) {
@@ -285,7 +315,11 @@ public class RestApiClient implements ApiClient {
             final String httpMethod = getHttpMethodFromMethodName(methodName);
             String methodId = methodInfo.instanceRequired() ? this.id : null;
             final String url = getFullUrl(serviceClass.getAnnotation(ApiService.class).value(),
-                    methodName, methodId, resultLimit, mask == null ? maskString : mask.getMask());
+                    methodName,
+                    methodId,
+                    resultLimit,
+                    mask == null ? maskString : mask.getMask(),
+                    getFilterString());
             final HttpClient client = getHttpClientFactory().getHttpClient(credentials, httpMethod, url, HEADERS);
 
             // Invoke with response
@@ -324,7 +358,11 @@ public class RestApiClient implements ApiClient {
             final String httpMethod = getHttpMethodFromMethodName(methodName);
             String methodId = methodInfo.instanceRequired() ? this.id : null;
             final String url = getFullUrl(serviceClass.getAnnotation(ApiService.class).value(),
-                    methodName, methodId, resultLimit, mask == null ? maskString : mask.getMask());
+                    methodName,
+                    methodId,
+                    resultLimit,
+                    mask == null ? maskString : mask.getMask(),
+                    getFilterString());
             final HttpClient client = getHttpClientFactory().getHttpClient(credentials, httpMethod, url, HEADERS);
             
             Callable<Void> setupBody = new Callable<Void>() {
@@ -422,6 +460,8 @@ public class RestApiClient implements ApiClient {
                 ServiceProxy<S> asyncProxy = new ServiceProxy<S>(serviceClass, id);
                 asyncProxy.mask = mask;
                 asyncProxy.maskString = maskString;
+                asyncProxy.filter = filter;
+                asyncProxy.filterString = filterString;
                 asyncProxy.resultLimit = resultLimit;
                 return Proxy.newProxyInstance(getClass().getClassLoader(),
                     new Class<?>[] { method.getReturnType() }, asyncProxy);
@@ -451,6 +491,33 @@ public class RestApiClient implements ApiClient {
             } else if ("clearMask".equals(method.getName())) {
                 mask = null;
                 maskString = null;
+                return null;
+            } else if ("withNewFilter".equals(method.getName()) && noParams) {
+                filter = (Mask) method.getReturnType().newInstance();
+                filterString = null;
+                return filter;
+            } else if ("withFilter".equals(method.getName()) && noParams) {
+                if (filter == null) {
+                    filter = (Mask) method.getReturnType().newInstance();
+                    filterString = null;
+                }
+                return filter;
+            } else if ("setFilter".equals(method.getName()) &&args != null
+                    && args.length == 1 && args[0] instanceof String) {
+                filter = null;
+                filterString = args[0].toString();
+                return null;
+            } else if ("setFilter".equals(method.getName()) && args != null
+                    && args.length == 1 && args[0] instanceof Mask) {
+                filter = (Mask) args[0];
+                filterString = null;
+                return null;
+            } else if ("setFilter".equals(method.getName()) && args != null
+                    && args.length == 1 && args[0] == null) {
+                throw new IllegalArgumentException("Cannot set null filter. Use clearFilter to remove a filter.");
+            } else if ("clearFilter".equals(method.getName())) {
+                filter = null;
+                filterString = null;
                 return null;
             } else if ("setResultLimit".equals(method.getName()) &&
                     method.getDeclaringClass() == ResultLimitable.class) {

--- a/src/main/java/com/softlayer/api/Service.java
+++ b/src/main/java/com/softlayer/api/Service.java
@@ -1,7 +1,7 @@
 package com.softlayer.api;
 
 /** Interface extended by individual service interfaces on types */
-public interface Service extends Maskable, ResultLimitable {
+public interface Service extends Maskable, Filterable, ResultLimitable {
     
     /** Get an async version of this service */
     public ServiceAsync asAsync();

--- a/src/test/java/com/softlayer/api/RestApiClientTest.java
+++ b/src/test/java/com/softlayer/api/RestApiClientTest.java
@@ -46,29 +46,29 @@ public class RestApiClientTest {
     public void testGetFullUrl() {
         RestApiClient client = new RestApiClient("http://example.com/");
         assertEquals("http://example.com/SomeService/someMethod.json",
-            client.getFullUrl("SomeService", "someMethod", null, null, null));
+            client.getFullUrl("SomeService", "someMethod", null, null, null, null));
         assertEquals("http://example.com/SomeService/1234/someMethod.json",
-            client.getFullUrl("SomeService", "someMethod", "1234", null, null));
+            client.getFullUrl("SomeService", "someMethod", "1234", null, null, null));
         assertEquals("http://example.com/SomeService/1234/someMethod.json?resultLimit=5,6",
-            client.getFullUrl("SomeService", "someMethod", "1234", new ResultLimit(5, 6), null));
+            client.getFullUrl("SomeService", "someMethod", "1234", new ResultLimit(5, 6), null, null));
         assertEquals("http://example.com/SomeService/1234/someMethod.json?resultLimit=5,6&objectMask=someMask%26%26",
-            client.getFullUrl("SomeService", "someMethod", "1234", new ResultLimit(5, 6), "someMask&&"));
+            client.getFullUrl("SomeService", "someMethod", "1234", new ResultLimit(5, 6), "someMask&&", null));
         assertEquals("http://example.com/SomeService/1234/someMethod.json?objectMask=someMask%26%26",
-            client.getFullUrl("SomeService", "someMethod", "1234", null, "someMask&&"));
+            client.getFullUrl("SomeService", "someMethod", "1234", null, "someMask&&", null));
         assertEquals("http://example.com/SomeService/Something.json",
-            client.getFullUrl("SomeService", "getSomething", null, null, null));
+            client.getFullUrl("SomeService", "getSomething", null, null, null, null));
         assertEquals("http://example.com/SomeService.json",
-            client.getFullUrl("SomeService", "getObject", null, null, null));
+            client.getFullUrl("SomeService", "getObject", null, null, null, null));
         assertEquals("http://example.com/SomeService.json",
-            client.getFullUrl("SomeService", "deleteObject", null, null, null));
+            client.getFullUrl("SomeService", "deleteObject", null, null, null, null));
         assertEquals("http://example.com/SomeService.json",
-            client.getFullUrl("SomeService", "createObject", null, null, null));
+            client.getFullUrl("SomeService", "createObject", null, null, null, null));
         assertEquals("http://example.com/SomeService.json",
-            client.getFullUrl("SomeService", "createObjects", null, null, null));
+            client.getFullUrl("SomeService", "createObjects", null, null, null, null));
         assertEquals("http://example.com/SomeService.json",
-            client.getFullUrl("SomeService", "editObject", null, null, null));
+            client.getFullUrl("SomeService", "editObject", null, null, null, null));
         assertEquals("http://example.com/SomeService.json",
-            client.getFullUrl("SomeService", "editObjects", null, null, null));
+            client.getFullUrl("SomeService", "editObjects", null, null, null, null));
     }
     
     private String withOutputCaptured(Callable<?> closure) throws Exception {
@@ -311,7 +311,8 @@ public class RestApiClientTest {
         TestEntity entity = new TestEntity();
         entity.setFoo("blah");
         TestEntity.Service service = TestEntity.service(client);
-        service.withMask().foo().child().date();
+        service.withMask().foo();
+        service.withMask().child().date();
         service.withMask().child().baz();
         assertEquals("some response", service.doSomethingStatic(123L, entity));
         assertEquals("http://example.com/SoftLayer_TestEntity/doSomethingStatic.json"
@@ -329,7 +330,8 @@ public class RestApiClientTest {
         entity.setFoo("blah");
         TestEntity.Service service = TestEntity.service(client);
         TestEntity.Mask mask = new TestEntity.Mask();
-        mask.foo().child().date();
+        mask.foo();
+        mask.child().date();
         mask.child().baz();
         service.setMask(mask);
         assertEquals("some response", service.doSomethingStatic(123L, entity));

--- a/src/test/java/com/softlayer/api/service/TestEntity.java
+++ b/src/test/java/com/softlayer/api/service/TestEntity.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.concurrent.Future;
 
 import com.softlayer.api.ApiClient;
+import com.softlayer.api.Property;
+import com.softlayer.api.Property.DateTimeProperty;
+import com.softlayer.api.Property.StringProperty;
 import com.softlayer.api.ResponseHandler;
 import com.softlayer.api.annotation.ApiMethod;
 import com.softlayer.api.annotation.ApiProperty;
@@ -161,19 +164,16 @@ public class TestEntity extends Entity {
     
     public static class Mask extends Entity.Mask {
         
-        public Mask foo() {
-            withLocalProperty("bar");
-            return this;
+        public StringProperty foo() {
+            return withStringProperty("foo");
         }
         
-        public Mask baz() {
-            withLocalProperty("baz");
-            return this;
+        public StringProperty baz() {
+            return withStringProperty("baz");
         }
         
-        public Mask date() {
-            withLocalProperty("date");
-            return this;
+        public DateTimeProperty date() {
+            return withDateTimeProperty("date");
         }
         
         public Mask child() {


### PR DESCRIPTION
Adds support for object filters by extending the functionality provided by `Mask` to allow a `Property` value on the local properties of the `Mask`.

`Service` objects are now `Filterable`, which means they have the ability to set a `Filter`.

This change is backwards incompatible due to the improvement with the way that masks are created.
