### PR TITLE
Use the meta name on masks instead of the name after converting for reserved keywords in java

### DIFF
--- a/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
+++ b/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
@@ -114,12 +114,12 @@ public class ClassWriter extends JavaWriter {
         for (TypeClass.Property property : type.properties) {
             if (property.nonArrayJavaType.startsWith("com.")) {
                 beginMethod(property.nonArrayJavaType + ".Mask", property.name, PUBLIC).
-                    emitStatement("return withSubMask(%s, %s.class)", stringLiteral(property.name),
+                    emitStatement("return withSubMask(%s, %s.class)", stringLiteral(property.meta.name),
                         compressType(property.nonArrayJavaType + ".Mask")).
                     endMethod().emitEmptyLine();
             } else {
                 beginMethod("Mask", property.name, PUBLIC).
-                    emitStatement("withLocalProperty(%s)", stringLiteral(property.name)).
+                    emitStatement("withLocalProperty(%s)", stringLiteral(property.meta.name)).
                     emitStatement("return this").
                     endMethod().emitEmptyLine();
             }


### PR DESCRIPTION
Some masks don't work because the name after conversion for java is not the same as the one that the API accepts.

An example is masking `itemPackage` on `billing.order.Item`. Instead of masking `package` via the API, the client sends `itemPackage` which will cause a server error.

This PR changes how mask code is emitted to use the meta names appropriately.