### PR TITLE
Fix for: ID is required to invoke public resource.Metadata$Service.getId()

### DIFF
--- a/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
+++ b/gen/src/main/java/com/softlayer/api/gen/ClassWriter.java
@@ -272,7 +272,7 @@ public class ClassWriter extends JavaWriter {
             if (!method.name.equals(method.meta.name)) {
                 params.put("value", stringLiteral(method.meta.name));
             }
-            if (!method.meta.isstatic) {
+            if (!method.meta.isstatic && !"SoftLayer_Resource_Metadata".equals(type.meta.name)) {
                 params.put("instanceRequired", true);
             }
             emitAnnotation(TYPE_API_METHOD, params);


### PR DESCRIPTION
This fix the issue #53, during testing I found another error which is thrown when calling to **getServiceResources**

`java.lang.RuntimeException: Expected 'complexType' as first property`

The call returns status 200, and the response is correct, the problem is when the retrieved data pass through GsonJsonMarshallerFactory. I think it should be fixed independently from this issue.