### PR TITLE
Allow type coercion when determining API types

### DIFF
--- a/src/main/java/com/softlayer/api/json/GsonJsonMarshallerFactory.java
+++ b/src/main/java/com/softlayer/api/json/GsonJsonMarshallerFactory.java
@@ -14,12 +14,8 @@ import java.math.BigInteger;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Supplier;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -191,12 +187,12 @@ class GsonJsonMarshallerFactory extends JsonMarshallerFactory implements JsonMar
             //  we're an adapter for. So if we have SoftLayer_Something and a newer release of the
             //  API has a type extending it but we don't have a generated class for it, it will get
             //  properly serialized to a SoftLayer_Something.
+            // If the API returns a type that isn't the same or a subtype of the type class,
+            //  try as best we can to fit the data within the type class.
             Class<? extends Entity> clazz = typeClasses.get(apiTypeName);
             Entity result;
-            if (clazz == null) {
+            if (clazz == null || !typeClass.isAssignableFrom(clazz)) {
                 result = readForThisType(in);
-            } else if (!typeClass.isAssignableFrom(clazz)) {
-                throw new RuntimeException("Expecting " + typeClass + " to be super type of " + clazz);
             } else {
                 result = ((EntityTypeAdapter) gson.getAdapter(clazz)).readForThisType(in);
             }

--- a/src/test/java/com/softlayer/api/service/TestEntity.java
+++ b/src/test/java/com/softlayer/api/service/TestEntity.java
@@ -11,7 +11,6 @@ import com.softlayer.api.annotation.ApiService;
 import com.softlayer.api.annotation.ApiType;
 import com.softlayer.api.ApiClient;
 import com.softlayer.api.ResponseHandler;
-import com.softlayer.api.ResultLimit;
 
 @ApiType("SoftLayer_TestEntity")
 public class TestEntity extends Entity {

--- a/src/test/java/com/softlayer/api/service/TestThing.java
+++ b/src/test/java/com/softlayer/api/service/TestThing.java
@@ -10,7 +10,9 @@ import com.softlayer.api.ResultLimit;
 import com.softlayer.api.annotation.ApiMethod;
 import com.softlayer.api.annotation.ApiProperty;
 import com.softlayer.api.annotation.ApiService;
+import com.softlayer.api.annotation.ApiType;
 
+@ApiType("SoftLayer_TestThing")
 public class TestThing extends Entity {
 
     @ApiProperty(canBeNullOrNotSet = true)


### PR DESCRIPTION
When we read objects from the API, we want to ensure the type matches
either the type class that the client is aware of, or whatever the
complexType property on the object tells us. In some cases, the API
returns a type for a property that is not the same or a subtype of the
type defined by the API. The API should not do this, however the
previous behavior was to throw an exception in these cases, which is
quite annoying. Instead, we will now coerce the object we get into the
type that the definition says. If properties are missing, they will
remain unset, and any extra properties will be added to the unknown
properties.

Fixes #63 