### PR TITLE
Bearer token auth support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 The SoftLayer Developer Network
+Copyright (c) 2021 The SoftLayer Developer Network
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ instantiate it and provide your credentials:
 
 
 #### Username and API Key
-For using a Classic Infrastructure or IBM Cloud API key. When using the IBM Cloud Api key, your username is litterally `apikey`, more information about that can be found on the SLDN [Authenticating to the SoftLayer API](https://sldn.softlayer.com/article/authenticating-softlayer-api/#cloud-api) article.
+For using a Classic Infrastructure or IBM Cloud API key. When using the IBM Cloud Api key, your username is the literal string `apikey`, more information about that can be found on the SLDN [Authenticating to the SoftLayer API](https://sldn.softlayer.com/article/authenticating-softlayer-api/#cloud-api) article.
 
 ```java
 import com.softlayer.api.*;

--- a/README.md
+++ b/README.md
@@ -40,20 +40,20 @@ additions to the SoftLayer API.
 <dependency>
   <groupId>com.softlayer.api</groupId>
   <artifactId>softlayer-api-client</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'com.softlayer.api:softlayer-api-client:0.3.1'
+implementation 'com.softlayer.api:softlayer-api-client:0.3.2'
 ```
 
 ### Kotlin
 
 ```kotlin
-compile("com.softlayer.api:softlayer-api-client:0.3.1")
+compile("com.softlayer.api:softlayer-api-client:0.3.2")
 ```
 
 ### Creating a Client
@@ -61,10 +61,22 @@ compile("com.softlayer.api:softlayer-api-client:0.3.1")
 All clients are instances of `ApiClient`. Currently there is only one implementation, the `RestApiClient`. Simply
 instantiate it and provide your credentials:
 
+
+#### Username and API Key
+For using a Classic Infrastructure or IBM Cloud API key. When using the IBM Cloud Api key, your username is litterally `apikey`, more information about that can be found on the SLDN [Authenticating to the SoftLayer API](https://sldn.softlayer.com/article/authenticating-softlayer-api/#cloud-api) article.
+
 ```java
 import com.softlayer.api.*;
 
 ApiClient client = new RestApiClient().withCredentials("my user", "my api key");
+```
+
+#### Acesses Token
+Information on how to get a temoprary api token can be found on the SLDN [Authenticating to the SoftLayer API](https://sldn.softlayer.com/article/authenticating-softlayer-api/#temp-token) article.
+
+```java
+import com.softlayer.api.*;
+ApiClient client = new RestApiClient().withBearerToken("qqqqwwwweeeaaassddd....");
 ```
 
 If the end point isn't at the normal SoftLayer API, you can provide the prefix to the constructor of the
@@ -296,4 +308,4 @@ fully qualified class name of your implementation on a single line in a file in 
 
 ## Copyright
 
-This software is Copyright (c) 2020 The SoftLayer Developer Network. See the bundled LICENSE file for more information.
+This software is Copyright (c) 2021 The SoftLayer Developer Network. See the bundled LICENSE file for more information.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import com.softlayer.api.*;
 ApiClient client = new RestApiClient().withCredentials("my user", "my api key");
 ```
 
-#### Acesses Token
+#### Access Token
 Information on how to get a temoprary api token can be found on the SLDN [Authenticating to the SoftLayer API](https://sldn.softlayer.com/article/authenticating-softlayer-api/#temp-token) article.
 
 ```java

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>softlayer-api-client-examples</artifactId>
   <packaging>jar</packaging>
   <!-- Please keep version in sync with README -->
-  <version>0.3.1</version>
+  <version>0.3.2</version>
   <name>softlayer-api-client-examples</name>
   <url>http://sldn.softlayer.com</url>
   <licenses>

--- a/examples/src/main/java/com/softlayer/api/example/Example.java
+++ b/examples/src/main/java/com/softlayer/api/example/Example.java
@@ -17,7 +17,14 @@ public abstract class Example {
             baseUrl += '/';
         }
 
-        run(new RestApiClient(baseUrl).withCredentials(args[0], args[1]));
+        RestApiClient client;
+        // mvn -e -q compile exec:java -Dexec.args="QuickTest Bearer eyJraWQ.....
+        if (args[0].trim().equals("Bearer")) {
+            client = new RestApiClient(baseUrl).withBearerToken(args[1]);
+        } else {
+            client = new RestApiClient(baseUrl).withCredentials(args[0], args[1]);
+        }
+        run(client);
     }
 
     /** Run the example with the given client */

--- a/examples/src/main/java/com/softlayer/api/example/QuickTest.java
+++ b/examples/src/main/java/com/softlayer/api/example/QuickTest.java
@@ -1,0 +1,28 @@
+package com.softlayer.api.example;
+
+import com.softlayer.api.ApiClient;
+import com.softlayer.api.RestApiClient;
+import com.softlayer.api.service.Account;
+
+
+/** A quick example for testing if authentication works. 
+
+cd softlayer-java/examples
+mvn -e -q compile exec:java -Dexec.args="QuickTest Bearer eyJraWQ.....
+*/
+public class QuickTest extends Example {
+
+    @Override
+    public void run(ApiClient client) throws Exception {
+        client.withLoggingEnabled();
+        System.out.format("Authorization: %s\n", client.getCredentials());
+        Account.Service service = Account.service(client);
+
+        Account account = service.getObject();
+        System.out.format("Account Name: %s\n", account.getCompanyName());
+    }
+
+    public static void main(String[] args) throws Exception {
+        new QuickTest().start(args);
+    }
+}

--- a/gen/pom.xml
+++ b/gen/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>softlayer-api-client-gen</artifactId>
   <packaging>jar</packaging>
   <!-- Please keep version in sync with README -->
-  <version>0.3.1</version>
+  <version>0.3.2</version>
   <name>softlayer-api-client-gen</name>
   <url>http://sldn.softlayer.com</url>
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>softlayer-api-client</artifactId>
   <packaging>jar</packaging>
   <!-- Please keep version in sync with README -->
-  <version>0.3.1</version>
+  <version>0.3.2</version>
   <name>SoftLayer API Client for Java</name>
   <description>API client for accessing the SoftLayer API</description>
   <url>http://sldn.softlayer.com</url>
@@ -40,7 +40,7 @@
     <connection>scm:git:git@github.com:softlayer/softlayer-java.git</connection>
     <developerConnection>scm:git:git@github.com:softlayer/softlayer-java.git</developerConnection>
     <url>git@github.com:softlayer/softlayer-java.git</url>
-    <tag>0.3.1</tag>
+    <tag>0.3.2</tag>
   </scm>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -160,6 +160,30 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.6</version>
+          <configuration>
+            <excludes>
+              <exclude>**/*com/softlayer/api/service/**/*</exclude>
+            </excludes>
+          </configuration>
+          <executions>
+              <execution>
+                  <goals>
+                      <goal>prepare-agent</goal>
+                  </goals>
+              </execution>
+              <execution>
+                  <id>report</id>
+                  <phase>prepare-package</phase>
+                  <goals>
+                      <goal>report</goal>
+                  </goals>
+              </execution>
+          </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/softlayer/api/ApiClient.java
+++ b/src/main/java/com/softlayer/api/ApiClient.java
@@ -1,5 +1,7 @@
 package com.softlayer.api;
 
+import com.softlayer.api.http.HttpCredentials;
+
 /** Common interface for all API clients. {@link RestApiClient} is the preferred implementation */
 public interface ApiClient {
     
@@ -9,7 +11,28 @@ public interface ApiClient {
      * @return This instance
      */
     ApiClient withCredentials(String username, String apiKey);
-    
+
+    /**
+     * Uses a HTTP Bearer token for authentication instead of API key.
+     *
+     * @return This instance
+     */
+    ApiClient withBearerToken(String token);
+
+    /**
+    * Enables logging for client API calls
+    *
+    * @return This instance
+    */
+    ApiClient withLoggingEnabled();
+
+    /**
+    * Returns the HTTP Authorization header
+    *
+    * @return This instance
+    */
+    HttpCredentials getCredentials();
+
     /**
      * Get a service for the given sets of classes and optional ID. It is not recommended to call this
      * directly, but rather invoke the service method on the type class.

--- a/src/main/java/com/softlayer/api/RestApiClient.java
+++ b/src/main/java/com/softlayer/api/RestApiClient.java
@@ -18,7 +18,9 @@ import java.util.concurrent.TimeoutException;
 
 import com.softlayer.api.annotation.ApiMethod;
 import com.softlayer.api.annotation.ApiService;
+import com.softlayer.api.http.HttpCredentials;
 import com.softlayer.api.http.HttpBasicAuthCredentials;
+import com.softlayer.api.http.HttpBearerCredentials;
 import com.softlayer.api.http.HttpClient;
 import com.softlayer.api.http.HttpClientFactory;
 import com.softlayer.api.http.HttpResponse;
@@ -64,7 +66,7 @@ public class RestApiClient implements ApiClient {
     private HttpClientFactory httpClientFactory;
     private JsonMarshallerFactory jsonMarshallerFactory;
     private boolean loggingEnabled = false;
-    private HttpBasicAuthCredentials credentials;
+    private HttpCredentials credentials;
 
     /**
      * Create a Rest client that uses the publically available API.
@@ -114,6 +116,7 @@ public class RestApiClient implements ApiClient {
         this.loggingEnabled = loggingEnabled;
     }
     
+    @Override
     public RestApiClient withLoggingEnabled() {
         this.loggingEnabled = true;
         return this;
@@ -141,7 +144,14 @@ public class RestApiClient implements ApiClient {
         return this;
     }
     
-    public HttpBasicAuthCredentials getCredentials() {
+    @Override
+    public RestApiClient withBearerToken(String token) {
+        credentials = new HttpBearerCredentials(token);
+        return this;
+    }
+
+    @Override
+    public HttpCredentials getCredentials() {
         return credentials;
     }
     

--- a/src/main/java/com/softlayer/api/http/BuiltInHttpClientFactory.java
+++ b/src/main/java/com/softlayer/api/http/BuiltInHttpClientFactory.java
@@ -89,7 +89,7 @@ class BuiltInHttpClientFactory extends ThreadPooledHttpClientFactory {
 
     class BuiltInHttpClient implements HttpClient, HttpResponse {
 
-        final HttpBasicAuthCredentials credentials;
+        final HttpCredentials credentials;
         final String method;
         final String fullUrl;
         final Map<String, List<String>> headers;
@@ -101,11 +101,7 @@ class BuiltInHttpClientFactory extends ThreadPooledHttpClientFactory {
             String fullUrl,
             Map<String, List<String>> headers
         ) {
-            // We only support basic auth
-            if (credentials != null && !(credentials instanceof HttpBasicAuthCredentials)) {
-                throw new UnsupportedOperationException("Only basic auth is supported, not " + credentials.getClass());
-            }
-            this.credentials = (HttpBasicAuthCredentials) credentials;
+            this.credentials = credentials;
             this.method = method;
             this.fullUrl = fullUrl;
             this.headers = headers;

--- a/src/main/java/com/softlayer/api/http/HttpBearerCredentials.java
+++ b/src/main/java/com/softlayer/api/http/HttpBearerCredentials.java
@@ -1,9 +1,13 @@
 package com.softlayer.api.http;
 
-/** HTTP bearer authorization support for bearer token fromhttps://iam.cloud.ibm.com/identity/token */
+/** HTTP Bearer authorization support for IBM IAM Tokens.
+ *
+ * @see <a href="https://cloud.ibm.com/apidocs/iam-identity-token-api">IAM Tokens</a>
+ * @see <a href="https://sldn.softlayer.com/article/authenticating-softlayer-api/">Authenticating SoftLayer API</a>
+ */
 public class HttpBearerCredentials implements HttpCredentials {
 
-    public final String token;
+    protected final String token;
     
     public HttpBearerCredentials(String token) {
         this.token = token;

--- a/src/main/java/com/softlayer/api/http/HttpBearerCredentials.java
+++ b/src/main/java/com/softlayer/api/http/HttpBearerCredentials.java
@@ -1,0 +1,20 @@
+package com.softlayer.api.http;
+
+/** HTTP bearer authorization support for bearer token fromhttps://iam.cloud.ibm.com/identity/token */
+public class HttpBearerCredentials implements HttpCredentials {
+
+    public final String token;
+    
+    public HttpBearerCredentials(String token) {
+        this.token = token;
+    }
+
+    /**
+     * Formats the token into a HTTP Authorization header.
+     *
+     * @return String
+     */
+    public String getHeader() {
+        return "Bearer " + token;
+    }
+}

--- a/src/main/java/com/softlayer/api/http/HttpCredentials.java
+++ b/src/main/java/com/softlayer/api/http/HttpCredentials.java
@@ -2,4 +2,5 @@ package com.softlayer.api.http;
 
 /** Base interface for all accepted HTTP credentials */
 public interface HttpCredentials {
+    public String getHeader();
 }

--- a/src/main/java/com/softlayer/api/http/HttpCredentials.java
+++ b/src/main/java/com/softlayer/api/http/HttpCredentials.java
@@ -2,5 +2,5 @@ package com.softlayer.api.http;
 
 /** Base interface for all accepted HTTP credentials */
 public interface HttpCredentials {
-    public String getHeader();
+    String getHeader();
 }

--- a/src/test/java/com/softlayer/api/http/BuiltInHttpClientFactoryTest.java
+++ b/src/test/java/com/softlayer/api/http/BuiltInHttpClientFactoryTest.java
@@ -16,21 +16,6 @@ import com.softlayer.api.http.BuiltInHttpClientFactory.BuiltInHttpClient;
 public class BuiltInHttpClientFactoryTest {
 
     @Test
-    public void testGetHttpClientWithoutBasicAuth() {
-        try {
-            new BuiltInHttpClientFactory().getHttpClient(
-                new HttpCredentials() { },
-                "GET",
-                "http://example.com",
-                Collections.emptyMap()
-            );
-            fail();
-        } catch (UnsupportedOperationException e) {
-            assertTrue(e.getMessage().contains("basic auth"));
-        }
-    }
-    
-    @Test
     public void testGetThreadPoolDefaultsToDaemonThreads() throws Exception {
         boolean daemon = new BuiltInHttpClientFactory().getThreadPool().submit(
             () -> Thread.currentThread().isDaemon()

--- a/src/test/java/com/softlayer/api/http/BuiltInHttpClientFactoryTest.java
+++ b/src/test/java/com/softlayer/api/http/BuiltInHttpClientFactoryTest.java
@@ -24,6 +24,14 @@ public class BuiltInHttpClientFactoryTest {
     }
 
     @Test
+    public void testGetThreadPoolLazyLoading() {
+        BuiltInHttpClientFactory factory = new BuiltInHttpClientFactory();
+        ExecutorService threadPool = factory.getThreadPool();
+        assertNotNull(threadPool);
+        assertEquals(threadPool, factory.getThreadPool());
+    }
+
+    @Test
     public void testSetThreadPoolShutsDownNonUserDefined() {
         BuiltInHttpClientFactory factory = new BuiltInHttpClientFactory();
         ExecutorService threadPool = mock(ExecutorService.class);

--- a/src/test/java/com/softlayer/api/http/HttpBearerCredentialsTest.java
+++ b/src/test/java/com/softlayer/api/http/HttpBearerCredentialsTest.java
@@ -1,0 +1,22 @@
+package com.softlayer.api.http;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class HttpBearerCredentialsTest {
+
+    public final String bearerToken = "qqqqwwwweeerrttyyuuiiooppasddfgfgjghjkjklZXxcvcvbvbnnbm";
+    @Test
+    public void testConstructor() {
+        HttpBearerCredentials authCredentials = new HttpBearerCredentials(bearerToken);
+        assertEquals(bearerToken, authCredentials.token);
+    }
+
+    @Test
+    public void testGetHeader() {
+        HttpBearerCredentials authCredentials = new HttpBearerCredentials(bearerToken);
+        String header = "Bearer " + bearerToken;
+        assertEquals(header, authCredentials.getHeader());
+    }
+}


### PR DESCRIPTION
Adds a `HttpBearerCredentials` class to support using a Bearer token for API calls
Added code coverage report generation
Changed the examples to support either Bearer or username/apikey